### PR TITLE
Set the process exit status after finishing the 'status' subcommand

### DIFF
--- a/lib/rabbit_wq/cli.rb
+++ b/lib/rabbit_wq/cli.rb
@@ -120,7 +120,8 @@ options:
     end
 
     def status
-      RabbitWQ::ServerDaemon.new( options ).status
+      result = RabbitWQ::ServerDaemon.new( options ).status
+      at_exit { exit result }
     end
 
   end

--- a/lib/rabbit_wq/server_daemon.rb
+++ b/lib/rabbit_wq/server_daemon.rb
@@ -46,13 +46,14 @@ module RabbitWQ
     end
 
     def status
-      out = "#{APP_NAME} "
+      $stdout.print "#{APP_NAME} "
       if process_exists?
-        out << "process running with PID: #{pid}"
+        $stdout.puts "process running with PID: #{pid}"
+        true
       else
-        out << "process does not exist"
+        $stdout.puts "process does not exist"
+        false
       end
-      $stdout.puts out
     end
 
    protected


### PR DESCRIPTION
This is necessary in order for other scripts to know that the status was nominal or troubled, since there is console output in either case.
